### PR TITLE
update to sha256

### DIFF
--- a/Formula/cling.rb
+++ b/Formula/cling.rb
@@ -7,7 +7,7 @@ class Cling < Formula
   homepage "https://github.com/sutoiku/cling"
   version "0.3.11"
   url "https://raw.githubusercontent.com/root-mirror/root/master/interpreter/cling/tools/packaging/cpt.py"
-  sha256 "9c6dc72a01f123588db6a0f67bb2ba7f074cfb3a8b2039082296de2acb8e8292"
+  sha256 "ea68176e3636a816e89ad14bd348061c7e47c3f1b0c4112c8f3a73b28162ad4e"
 
   bottle do
     root_url "http://homebrew.stoic.com"


### PR DESCRIPTION
I'm not sure, but I think that the sha256 for one of the files in this script is out of date.

This came up while trying to get Stoic building/running, at the dependency installation step-- node, boost, eigen, and  postgresql install without problems, but sutoiku/stoic-public/cling fails:

``` bash
$ brew install node boost eigen postgresql sutoiku/stoic-public/cling
Warning: node 15.5.1 is already installed and up-to-date
To reinstall 15.5.1, run `brew reinstall node`
Warning: boost 1.75.0_1 is already installed and up-to-date
To reinstall 1.75.0_1, run `brew reinstall boost`
Warning: eigen 3.3.9 is already installed and up-to-date
To reinstall 3.3.9, run `brew reinstall eigen`
Warning: postgresql 13.1 is already installed and up-to-date
To reinstall 13.1, run `brew reinstall postgresql`
==> Installing cling from sutoiku/stoic-public
==> Downloading https://linuxbrew.bintray.com/bottles/cmake-3.19.2.x86_64_linux.bottle.tar.gz
Already downloaded: ~/.cache/Homebrew/downloads/17846699ee779c3f929b1463a7558058d47bb6e28db647c393f53107d3b450b2--cmake-3.19.2.x86_64_linux.bottle.tar.gz
==> Downloading https://raw.githubusercontent.com/root-mirror/root/master/interpreter/cling/tools/packaging/cpt.py
Already downloaded: ~/.cache/Homebrew/downloads/261cc2465627d04cc8c0354769c53d5e97cc43577b4a01eeaaa0635171440319--cpt.py
Error: SHA256 mismatch
Expected: 9c6dc72a01f123588db6a0f67bb2ba7f074cfb3a8b2039082296de2acb8e8292
  Actual: ea68176e3636a816e89ad14bd348061c7e47c3f1b0c4112c8f3a73b28162ad4e
    File: ~/.cache/Homebrew/downloads/261cc2465627d04cc8c0354769c53d5e97cc43577b4a01eeaaa0635171440319--cpt.py
To retry an incomplete download, remove the file above.
```

If I manually curl and sha256 the file, I get the same hash shown in the error:

```bash
$ curl https://raw.githubusercontent.com/root-mirror/root/master/interpreter/cling/tools/packaging/cpt.py | sha256sum
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   98k  100   98k    0     0  1558k      0 --:--:-- --:--:-- --:--:-- 1558k
ea68176e3636a816e89ad14bd348061c7e47c3f1b0c4112c8f3a73b28162ad4e  -
```

Which leads me to believe the sha256 is out of date.

BUT: (1) I'm trying a linux installation and (2) I've never used brew before, so I may be totally incorrect, or it may be that something else is behind my problem.

(fyi @Y-- )